### PR TITLE
v0.2.0-pre

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ See the [LICENCE](LICENCE) file for terms.
 
 | Version | Number of Recipes | Minutes:Seconds 🠗 | # Webpages DLed | Derived ----> | webpages DLed/recipe 🠗 | seconds/recipe 🠗 | 
 | :------ | :---------------: | :---------------: | :-------------: | ------------- | :--------------------: | :-------------: |
+| 0.2.0-pre | 20 | 1:28 | 51* | | 2.6 | 4.4 |
 | 0.1.0 | 20 | 1:16 | 39 | | 2 | 3.8 |
 | 0.0.2 | 20 | 4:00 | 79 | | 4 | 12 |
 | 0.0.1 | 20 | 7:20 | 122 | | 6 | 22 |
 
 🠗 symbol indicates that for the statistic being lower is better
+* first version to detect duplicate recipes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4
 loguru
+recipe-scrapers>=13.2.8
 requests
 scrape-schema-recipe>=0.1.3
 pendulum

--- a/taste.py
+++ b/taste.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import json
+import platform 
+import pprint
+import sys
+
+
+def usage():
+    prompt = '$'
+    if platform.system() == "Windows":
+        prompt = "C:\..>"
+
+    usage_msg = f"""
+Tool for tasting (inspecting) a JSON cookbook.
+       {prompt} taste.py [cookbook.json] [attribute]
+
+       {prompt} taste.py [cookbook.json] attrs
+            List the attributes.
+    """
+    return usage_msg
+
+if __name__ == "__main__":
+    pp = pprint.PrettyPrinter()
+    if len(sys.argv) < 3:
+        print(usage())
+        sys.exit(0)
+    
+    with open(sys.argv[1], "r") as fp:
+        cookbook = json.load(fp)
+
+    if sys.argv[2] == 'attrs':
+        attrs = set()
+        for recipe in cookbook:
+            attrs = attrs.union(tuple(recipe.keys()))
+
+        attr_str = ', '.join(attrs)
+        # TODO: print this nicer 
+        pp.pprint(f'Attributes:  {attrs}')
+        sys.exit(0)
+
+    if sys.argv[2].isdigit() is True:
+        idx = int(sys.argv[2])
+        if idx >= len(cookbook):
+            print(f"Cookbook only has {len(cookbook)} recipes.  Try a smaller number.")
+            sys.exit(1)
+        elif idx < 0:
+            print(f"Negative numbered recipes are not valid input. The number of recipes starts at 0.")     
+            sys.exit(1)
+
+        pp.pprint(cookbook[idx])
+        sys.exit(0)
+
+    results = [recipe.get(sys.argv[2]) for recipe in cookbook]
+    pp.pprint(results)
+

--- a/website_source-open_source.yaml
+++ b/website_source-open_source.yaml
@@ -2,17 +2,43 @@
 site:
   url: https://bevvy.co/cocktails
   title: Bevvy
+  recipe_url: https://bevvy.co/cocktail/
   license: https://creativecommons.org/licenses/by-sa/3.0/
 ---
 site:
   url: https://www.midgetmomma.com/
   title: Midget Momma
+  start_url: https://www.midgetmomma.com/recipe-index
   license: https://creativecommons.org/licenses/by-nc-sa/3.0/
-  ---
+---
 site:
   url: https://www.crumbblog.com/
   license: https://creativecommons.org/licenses/by-nc/3.0/
   title: "Crumb: A Food Blog"
   author: Isabell Boucher
   author-link: http://www.sweetestkitchen.com/about/
-  fake_user_agent: yes
+---
+site:
+  url: https://histaminefriendlykitchen.com/
+  title: The Histamine Friendly Kitchen
+  license: https://creativecommons.org/licenses/by-nc-sa/4.0/
+---
+site:
+  url: https://www.myplate.gov/
+  title: USDA MyPlate
+  recipe_url: https://www.myplate.gov/recipes/
+  start_url: https://www.myplate.gov/myplate-kitchen/recipes
+  license: https://www.usda.gov/policies-and-links
+---
+site:
+  url: https://medlineplus.gov/
+  title: "NIH Medline Plus - Healthy Recipes"
+  start_url: https://medlineplus.gov/recipes/
+  recipe_url: https://medlineplus.gov/recipes/
+  license: https://www.nlm.nih.gov/web_policies.html#copyright
+---
+site:
+  url: https://healthyeating.nhlbi.nih.gov/
+  title: NIH Healthy Eating
+  recipe_url:  https://healthyeating.nhlbi.nih.gov/recipedetail.aspx?
+  license: https://www.nhlbi.nih.gov/about/contact/trademark-branding-and-logo

--- a/website_sources.yaml
+++ b/website_sources.yaml
@@ -5,7 +5,6 @@ site:
   title: "Crumb: A Food Blog"
   author: Isabell Boucher
   author-link: http://www.sweetestkitchen.com/about/
-  fake_user_agent: yes
 ---
 site:
   url: https://www.allrecipes.com/
@@ -20,7 +19,6 @@ site:
   title: FoodNetwork
   license: Proprietary
   distribute: no
-  fake_user_agent: yes
 ---
 site: 
   url: https://www.food.com/
@@ -34,13 +32,14 @@ site:
   title: TheKitchn
   license: Proprietary
   distribute: no
-  fake_user_agent: yes
 ---
 site:
   url: https://www.chowhound.com/
   title: Chowhound
   license: Proprietary
   distribute: no
+  start_url: https://www.chowhound.com/recipes
+  recipe_url: https://www.chowhound.com/recipes/
 ---
 site:
   url: https://bevvy.co/
@@ -52,8 +51,23 @@ site:
   url: https://www.midgetmomma.com/
   title: Midget Momma
   license: https://creativecommons.org/licenses/by-nc-sa/3.0/
+  start_url: https://www.midgetmomma.com/recipe-index
 ---
 site:
   url: https://histaminefriendlykitchen.com/
   title: The Histamine Friendly Kitchen
   license: https://creativecommons.org/licenses/by-nc-sa/4.0/
+---
+site:
+  url: https://www.myplate.gov/
+  title: USDA MyPlate
+  recipe_url: https://www.myplate.gov/recipes/
+  start_url: https://www.myplate.gov/myplate-kitchen/recipes
+  license: https://www.usda.gov/policies-and-links
+---
+site:
+  url: https://medlineplus.gov/
+  title: NIH Medline Plus - Healthy Recipes
+  start_url: https://medlineplus.gov/recipes/
+  recipe_url: https://medlineplus.gov/recipes/
+  license: view-source:https://www.nlm.nih.gov/web_policies.html#copyright


### PR DESCRIPTION
* Fixed bug where robots.txt parser was disallowing some websites.
* Add command line option to filter out a website by keyword
* Add taste.py a CLI program that allows you examine a field in all of the recipes in the cookbook
* When there is the same recipe in from the same website, don't add duplicate copy.  Fixes Issue #2  (There could still be the same recipe on multiple websites that isn't detected.)
* Add RecipeScraperCrawler for a few website that don't follow schema.org/Recipe format.  (Not quite ready for release.)
           - issue in `recipe-scrapers`, which makes this not quite ready for release.
* TODO: Exceptions to be implemented.
* TODO: Debug printing is a little too verbose for a release.