### PR TITLE
Remove reppy, add Crawl-delay, prep for 0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 donotinclude/
+.venv/
 *.json
 *.log
 licenses*.md

--- a/README.md
+++ b/README.md
@@ -81,10 +81,14 @@ OR Install the python libraries individually:
 * [Pendulum](https://pendulum.eustace.io/)
 * [PyYAML](https://pyyaml.org/)
 * [requests](https://docs.python-requests.org/)
-* [reppy](https://github.com/seomoz/reppy)
 * [recipe-scrapers](https://github.com/hhursev/recipe-scrapers)
 * [scrape-schema-recipe](https://github.com/micahcochran/scrape-schema-recipe)
 
+
+For development, install the dependent libaries typing:
+```
+> pip install -r requirements-dev.txt
+```
 ### Optional Dependency
 If you want to download pages using [Brotli compression](https://en.wikipedia.org/wiki/Brotli)
 * ensure requests >= 2.26.0 is installed, in order to check your request version (two ways)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development related requirements including types
+types-beautifulsoup4
+types-PyYAML
+types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 loguru
-recipe-scrapers>=13.3.3
+recipe-scrapers>=14.48.0
 requests
-scrape-schema-recipe>=0.1.3
+scrape-schema-recipe>=0.2.2
 pendulum
 PyYAML

--- a/website_source-open_source.yaml
+++ b/website_source-open_source.yaml
@@ -42,3 +42,10 @@ site:
   title: NIH Healthy Eating
   recipe_url:  https://healthyeating.nhlbi.nih.gov/recipedetail.aspx?
   license: https://www.nhlbi.nih.gov/about/contact/trademark-branding-and-logo
+---
+site:
+  url: https://www.foodista.com/
+  title: Foodista
+  start_url: https://www.foodista.com/blog/recipes-cooking
+  recipe_url: https://www.foodista.com/recipe/
+  license: http://creativecommons.org/licenses/by/3.0/

--- a/website_sources.yaml
+++ b/website_sources.yaml
@@ -71,3 +71,10 @@ site:
   start_url: https://medlineplus.gov/recipes/
   recipe_url: https://medlineplus.gov/recipes/
   license: https://www.nlm.nih.gov/web_policies.html#copyright
+---
+site:
+  url: https://www.foodista.com/
+  title: Foodista
+  start_url: https://www.foodista.com/blog/recipes-cooking
+  recipe_url: https://www.foodista.com/recipe/
+  license: http://creativecommons.org/licenses/by/3.0/


### PR DESCRIPTION
* Remove reppy dependency, this is a C++ dependency, replaced with Python standard library `urllib.robotparser`.  Merging closes Issue #10.
* Add support for `Crawl-delay` in `robots.txt`, which requires a certain number of second delay between page requests. 
* Add website Foodista as a source.
* Update recipe-scrapers to work with 14.48.0.  The library's interface has been improved.
* Correct some of the typing syntax.  There are still some issues.
* Add requirements-dev.txt for development.  It adds external libraries typing. 
* Prepare for version 0.4.0.

~~**TODO:** Update `requirements.txt` based on soon scrape-schema-recipe release.~~  
Update `requirements.txt` to newer dependencies in f07ecef

